### PR TITLE
setenv CCLAW_HTTPS in gunicorn.*.py so vue.config.js uses HTTPS

### DIFF
--- a/natural4-server/natural4_server/gunicorn.8010.py
+++ b/natural4-server/natural4_server/gunicorn.8010.py
@@ -9,7 +9,8 @@ raw_env = ["basedir="       + ".",
            "V8K_WORKDIR="   + "/home/mengwong/wow/much",
            "v8k_startport=" + str(bindport + 1),
            "v8k_path="      + "/home/mengwong/src/smucclaw/vue-pure-pdpa/bin/v8k",
-           "natural4_exe="  + "natural4-prod"
+           "natural4_exe="  + "natural4-prod",
+           "CCLAW_HTTPS="   + "true, set in gunicorn.conf.py so production supports https"
            ]
 bind     = "0.0.0.0:" + str(bindport)
 

--- a/natural4-server/natural4_server/gunicorn.8080.py
+++ b/natural4-server/natural4_server/gunicorn.8080.py
@@ -9,7 +9,8 @@ raw_env = ["basedir="       + ".",
            "V8K_WORKDIR="   + "/home/mengwong/wow/much",
            "v8k_startport=" + str(bindport + 1),
            "v8k_path="      + "/home/mengwong/src/smucclaw/vue-pure-pdpa/bin/v8k",
-           "natural4_exe="  + "natural4-stable"
+           "natural4_exe="  + "natural4-stable",
+           "CCLAW_HTTPS="   + "true, set in gunicorn.conf.py so production supports https"
            ]
 bind     = "0.0.0.0:" + str(bindport)
 

--- a/natural4-server/natural4_server/gunicorn.8090.py
+++ b/natural4-server/natural4_server/gunicorn.8090.py
@@ -10,7 +10,8 @@ raw_env = ["basedir="       + ".",
            "V8K_WORKDIR="   + "/home/mengwong/wow/much",
            "v8k_startport=" + str(bindport + 1),
            "v8k_path="      + "/home/mengwong/src/smucclaw/vue-pure-pdpa/bin/v8k",
-           "natural4_exe="  + "natural4-unstable"
+           "natural4_exe="  + "natural4-unstable",
+           "CCLAW_HTTPS="   + "true, set in gunicorn.conf.py so production supports https"
            ]
 bind     = "0.0.0.0:" + str(bindport)
 

--- a/natural4-server/natural4_server/gunicorn.conf.py
+++ b/natural4-server/natural4_server/gunicorn.conf.py
@@ -9,7 +9,9 @@ raw_env = ["basedir="       + ".",
            "V8K_WORKDIR="   + "/home/mengwong/wow/much",
            "v8k_startport=" + str(bindport + 1),
            "v8k_path="      + "/home/mengwong/src/smucclaw/vue-pure-pdpa/bin/v8k",
-           "natural4_exe="  + "natural4-exe"
+           "natural4_exe="  + "natural4-exe",
+           "CCLAW_HTTPS="   + "true, set in gunicorn.conf.py so production supports https"
+           # for details on CCLAW_HTTPS, see vue-pure-pdpa/vue.config.js
            ]
 bind     = "0.0.0.0:" + str(bindport)
 

--- a/natural4-server/natural4_server/gunicorn.joe.py
+++ b/natural4-server/natural4_server/gunicorn.joe.py
@@ -8,6 +8,7 @@ raw_env = ["basedir="       + ".",
            "V8K_WORKDIR="   + "/home/joe/v8k_workdir",
            "v8k_startport=" + "8201",
            "v8k_path="      + "/home/mengwong/src/smucclaw/vue-pure-pdpa/bin/v8k",
+           "CCLAW_HTTPS="   + "true, set in gunicorn.conf.py so production supports https",
            # "maudedir="      + ""
            ]
 bind     = "0.0.0.0:8200"


### PR DESCRIPTION
for details, see vue-pure-pdpa/vue.config.js