### PR TITLE
temp workaround: skip poetry lock hook in precommit ci to get around …

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+    skip: [poetry-lock]
+    
 minimum_pre_commit_version: "2.9.0"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
…connection timeout. Need to revisit this in the fuutre